### PR TITLE
disable gpu_acceleration

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -27,7 +27,7 @@ main:
   mounts:
     main: /root/data
     userdir: /config
-  gpu-acceleration: true
+  gpu-acceleration: false
 hardware-requirements:
   arch:
     - x86_64


### PR DESCRIPTION
Doesn't seem to add any noticable difference for Sparrow and gives warnings and errors on aarch64 (Pi4).