### PR TITLE
chore: bump sdk to 1.5.3, add version 2.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "sparrow-webtop",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1",
+        "@start9labs/start-sdk": "^1.5.3",
         "bitcoind-startos": "git+https://github.com/Start9Labs/bitcoind-startos.git#b394a28eca85868d432cd4f91e0015cb3ca3edd4",
         "js-yaml": "^4.1.1"
       },
@@ -64,9 +64,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.1.tgz",
-      "integrity": "sha512-iztLiOCtHuTfUCd2JOWio4OvBk5qFGa0NI+G+ZB/dQ1sWtunYEnzqMcF6N/Ss4L6+7bBOMAMU4VuhyxeZoHyIw==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.3.tgz",
+      "integrity": "sha512-OyHe9J6hMvyA5ZavcLkxdVQvZcuTH9J9kagV6NDI83eAG/YpJFIq62gP/n/2PPNdHWwNSXVQmSwnsvsV8Gyg+A==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.5.1",
+    "@start9labs/start-sdk": "^1.5.3",
     "bitcoind-startos": "git+https://github.com/Start9Labs/bitcoind-startos.git#b394a28eca85868d432cd4f91e0015cb3ca3edd4",
     "js-yaml": "^4.1.1"
   },

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -72,7 +72,9 @@ export const main = sdk.setupMain(async ({ effects }) => {
         // copy the .cookie file to a location where we can chown it
         const srcPath = `${subcontainer.rootfs}/tmp/bitcoin/.cookie`
         const destPath = `${subcontainer.rootfs}/mnt/bitcoin/.cookie`
-        await fs.mkdir(`${subcontainer.rootfs}/mnt/bitcoin`, { recursive: true })
+        await fs.mkdir(`${subcontainer.rootfs}/mnt/bitcoin`, {
+          recursive: true,
+        })
         await fs.copyFile(srcPath, destPath)
         await fs.chown(destPath, 1000, 1000)
         await fs.chmod(destPath, 0o400)

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,9 +1,10 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v2_4_2, SPARROW_VERSION } from './v2_4_2'
+import { v2_5_1, SPARROW_VERSION } from './v2_5_1'
+import { v2_4_2 } from './v2_4_2'
 
 export const versionGraph = VersionGraph.of({
-  current: v2_4_2,
-  other: [],
+  current: v2_5_1,
+  other: [v2_4_2],
 })
 
 export { SPARROW_VERSION }

--- a/startos/versions/v2_5_1.ts
+++ b/startos/versions/v2_5_1.ts
@@ -1,0 +1,18 @@
+import { IMPOSSIBLE, VersionInfo } from '@start9labs/start-sdk'
+
+export const v2_5_1 = VersionInfo.of({
+  version: '2.5.1:0',
+  releaseNotes: {
+    en_US: 'Update Sparrow to 2.5.1',
+    es_ES: 'Actualizar Sparrow a 2.5.1',
+    de_DE: 'Sparrow auf 2.5.1 aktualisieren',
+    pl_PL: 'Zaktualizuj Sparrow do wersji 2.5.1',
+    fr_FR: 'Mettre à jour Sparrow vers 2.5.1',
+  },
+  migrations: {
+    up: async ({ effects }) => {},
+    down: IMPOSSIBLE,
+  },
+})
+
+export const SPARROW_VERSION = '2.5.1'


### PR DESCRIPTION
- Bumps @start9labs/start-sdk to 1.5.3\n- Adds startos/versions/v2_5_1.ts with version 2.5.1:0\n- Updates versions/index.ts to set v2_5_1 as current, v2_4_2 in other\n- Updates docker image tag to 2.5.1 (via SPARROW_VERSION)