### PR TITLE
chore: bump Sparrow to 2.5.2

### DIFF
--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,15 +1,15 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
-export const SPARROW_VERSION = '2.5.1'
+export const SPARROW_VERSION = '2.5.2'
 
 export const current = VersionInfo.of({
-  version: '2.5.1:2',
+  version: '2.5.2:0',
   releaseNotes: {
-    en_US: 'Fix crash loop on startup when using public Electrum server',
-    es_ES: 'Corregir bucle de fallos al iniciar con servidor Electrum público',
-    de_DE: 'Absturz-Schleife beim Start mit öffentlichem Electrum-Server beheben',
-    pl_PL: 'Napraw pętlę awarii przy uruchomieniu z publicznym serwerem Electrum',
-    fr_FR: "Corriger la boucle de plantage au démarrage avec un serveur Electrum public",
+    en_US: 'Update Sparrow to 2.5.2',
+    es_ES: 'Actualizar Sparrow a 2.5.2',
+    de_DE: 'Sparrow auf 2.5.2 aktualisieren',
+    pl_PL: 'Zaktualizuj Sparrow do wersji 2.5.2',
+    fr_FR: 'Mettre à jour Sparrow vers 2.5.2',
   },
   migrations: {
     up: async ({ effects }) => {},


### PR DESCRIPTION
Bump Sparrow from 2.5.1 to 2.5.2.

Container image: `ghcr.io/remcoros/sparrow-webtop:2.5.2`

Upstream release notes: https://github.com/sparrowwallet/sparrow/releases/tag/2.5.2